### PR TITLE
Preserve directory structure in output filename generation

### DIFF
--- a/migri_assistant/parsers/base_parser.py
+++ b/migri_assistant/parsers/base_parser.py
@@ -257,28 +257,30 @@ class BaseParser(ABC):
     def _get_output_filename(self, html_file_path: Path) -> str:
         """
         Generate an output filename for the parsed markdown file.
+        Preserves the directory structure from the input directory.
 
         Args:
             html_file_path: Path to the source HTML file
 
         Returns:
-            Output filename (without extension)
+            Output filename with path (without extension)
         """
-        # Try to extract domain from the file path
+        # Try to extract relative path from the file path
         try:
             rel_path = html_file_path.relative_to(self.input_dir)
             parts = rel_path.parts
-            # If there are at least two parts (domain and path), use them
+
+            # If there are parts (domain and path), preserve the structure
             if len(parts) >= 2:
-                # Join all parts except the first (domain) with underscores
-                file_stem = "_".join(parts[1:]).replace(".html", "")
+                # Preserve the original directory structure but replace .html extension
+                rel_output_path = str(rel_path).replace(".html", "")
+                return rel_output_path
             else:
-                file_stem = html_file_path.stem
+                # Just use filename if there's only one part
+                return html_file_path.stem
         except ValueError:
             # If the file is not in the input directory, just use its name
-            file_stem = html_file_path.stem
-
-        return file_stem
+            return html_file_path.stem
 
     def _save_markdown(
         self,

--- a/tests/parsers/test_base_parser.py
+++ b/tests/parsers/test_base_parser.py
@@ -162,7 +162,7 @@ class TestBaseParser(unittest.TestCase):
         # Test file inside the input directory
         file_path = Path(os.path.join(self.input_dir, self.domain1, "test.html"))
         filename = self.parser._get_output_filename(file_path)
-        self.assertEqual(filename, "test")
+        self.assertEqual(filename, f"{self.domain1}/test")
 
         # Test file with subdirectories
         file_path = Path(
@@ -173,7 +173,7 @@ class TestBaseParser(unittest.TestCase):
             f.write("<html><body><h1>Subdir Page</h1></body></html>")
 
         filename = self.parser._get_output_filename(file_path)
-        self.assertEqual(filename, "subdir_page")
+        self.assertEqual(filename, f"{self.domain1}/subdir/page")
 
         # Test file outside the input directory
         outside_file = os.path.join(self.temp_dir, "outside.html")


### PR DESCRIPTION
Update the output filename generation to maintain the directory structure from the input HTML files, ensuring that the output reflects the original hierarchy.

This pull request updates the `_get_output_filename` method in the `BaseParser` class to preserve the directory structure of input files when generating output filenames. Corresponding test cases in the `test_base_parser.py` file have also been updated to reflect this change.

### Changes to directory structure preservation:

* [`migri_assistant/parsers/base_parser.py`](diffhunk://#diff-83ec4c393df6cdeec27926d7fcc0ca1c1481965e5121f7bcd9fda82ea6f4adbfR260-R283): Modified `_get_output_filename` to preserve the directory structure of input files in the output path. If the file is within the input directory, the relative path is used with the `.html` extension replaced. If not, the filename is used as before.

### Updates to test cases:

* [`tests/parsers/test_base_parser.py`](diffhunk://#diff-99e5aa1378baa4cdefcdbd0ea6ee80437f47059c4d2047f98f61bedea81db3c2L165-R165): Updated `test_get_output_filename` to verify that the output filename includes the relative directory structure for files inside the input directory. Adjusted assertions to check for paths like `domain1/test` and `domain1/subdir/page`. [[1]](diffhunk://#diff-99e5aa1378baa4cdefcdbd0ea6ee80437f47059c4d2047f98f61bedea81db3c2L165-R165) [[2]](diffhunk://#diff-99e5aa1378baa4cdefcdbd0ea6ee80437f47059c4d2047f98f61bedea81db3c2L176-R176)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Output filenames for parsed markdown files now preserve the original directory structure, making it easier to organize and locate files.
- **Tests**
  - Updated tests to reflect the new output filename format that maintains directory hierarchy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->